### PR TITLE
Use ssize_t for height/width iteration

### DIFF
--- a/Image.cc
+++ b/Image.cc
@@ -740,8 +740,8 @@ void Image::write_pixel(ssize_t x, ssize_t y, uint64_t r, uint64_t g,
 }
 
 void Image::reverse_horizontal() {
-  for (size_t y = 0; y < this->height; y++) {
-    for (size_t x = 0; x < this->width / 2; x++) {
+  for (ssize_t y = 0; y < this->height; y++) {
+    for (ssize_t x = 0; x < this->width / 2; x++) {
       uint64_t r1, g1, b1, a1, r2, g2, b2, a2;
       this->read_pixel(x, y, &r1, &g1, &b1, &a1);
       this->read_pixel(this->width - x - 1, y, &r2, &g2, &b2, &a2);
@@ -752,8 +752,8 @@ void Image::reverse_horizontal() {
 }
 
 void Image::reverse_vertical() {
-  for (size_t y = 0; y < this->height / 2; y++) {
-    for (size_t x = 0; x < this->width; x++) {
+  for (ssize_t y = 0; y < this->height / 2; y++) {
+    for (ssize_t x = 0; x < this->width; x++) {
       uint64_t r1, g1, b1, a1, r2, g2, b2, a2;
       this->read_pixel(x, y, &r1, &g1, &b1, &a1);
       this->read_pixel(x, this->height - y - 1, &r2, &g2, &b2, &a2);


### PR DESCRIPTION
Hi,

Running `make` on Debian 10 (buster), I got this error:
```
g++ -fPIC -std=c++14 -g -DHAVE_INTTYPES_H -DHAVE_NETINET_IN_H -Wall -Werror -DLINUX   -c -o Image.o Image.cc
Image.cc: In member function ‘void Image::reverse_horizontal()’:
Image.cc:743:24: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘ssize_t’ {aka ‘long int’} [-Werror=sign-compare]
   for (size_t y = 0; y < this->height; y++) {
                      ~~^~~~~~~~~~~~~~
Image.cc:744:26: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘ssize_t’ {aka ‘long int’} [-Werror=sign-compare]
     for (size_t x = 0; x < this->width / 2; x++) {
                        ~~^~~~~~~~~~~~~~~~~
Image.cc: In member function ‘void Image::reverse_vertical()’:
Image.cc:755:24: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘ssize_t’ {aka ‘long int’} [-Werror=sign-compare]
   for (size_t y = 0; y < this->height / 2; y++) {
                      ~~^~~~~~~~~~~~~~~~~~
Image.cc:756:26: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘ssize_t’ {aka ‘long int’} [-Werror=sign-compare]
     for (size_t x = 0; x < this->width; x++) {
                        ~~^~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make: *** [<builtin>: Image.o] Error 1
```

I was able to resolve this issue by adjusting `size_t` to `ssize_t` for all these errors. After that, I was able to build successfully.

I'm not sure if anyone else has encountered this issue or if this is a valid fix in the long-term, but I thought I would share my solution just in case.

Thanks for all your hard work!