### PR TITLE
Fix issue #4 header dependencies

### DIFF
--- a/KDTree-inl.hh
+++ b/KDTree-inl.hh
@@ -7,6 +7,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <stdexcept>
 
 
 

--- a/KDTree.hh
+++ b/KDTree.hh
@@ -5,6 +5,7 @@
 #include <deque>
 #include <memory>
 #include <vector>
+#include <sys/types.h>
 
 
 


### PR DESCRIPTION
Hello,

While running `make` on Gentoo with GCC 10.2.5, I got the same compilation errors as shown in the latest comment on issue #4. I added a couple more #include lines, and then I was able to successfully compile. I'm not sure if this is the best way to fix the issue, but I hope it is helpful.