### PR TITLE
Link pthread into phosg by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ link_directories("/usr/local/lib")
 # Library and executable definitions
 
 add_library(phosg src/Encoding.cc src/Filesystem.cc src/Hash.cc src/Image.cc src/JSON.cc src/Network.cc src/Process.cc src/Random.cc src/Strings.cc src/Time.cc src/Tools.cc src/UnitTest.cc)
+target_link_libraries(phosg pthread)
 
 add_executable(jsonformat src/JSONFormat.cc)
 target_link_libraries(jsonformat phosg)


### PR DESCRIPTION
Using g++-9 on Ubuntu 16.04, I got errors of the form

```
[ 34%] Linking CXX executable jsonformat
libphosg.a(Process.cc.o): In function `maybe_add_atfork_handler()':
/tmp/tmpibvp6fnb/phosg/src/Process.cc:210: undefined reference to `pthread_atfork'
collect2: error: ld returned 1 exit status
```

Online discussion says `pthread_atfork` is sometimes part of libc instead of pthreads. I'm not sure what the exact conditions are, but linking in pthreads explicitly seems safer.

phosg builds for me with this line on both Ubuntu 16.04 and 20.04.