### PR TITLE
_exit when execv* fails

### DIFF
--- a/src/Process.cc
+++ b/src/Process.cc
@@ -303,7 +303,7 @@ Subprocess::Subprocess(const vector<string>& cmd, int stdin_fd, int stdout_fd,
       execvp(cmd[0].c_str(), (char* const *)argv.data());
     }
     // if we get here, fork() worked, but execv_() failed: exit child process without even doing cleanup
-    _exit(errno);
+    _exit(1);
   }
 
   for (int fd : parent_fds_to_close) {

--- a/src/Process.cc
+++ b/src/Process.cc
@@ -269,7 +269,8 @@ Subprocess::Subprocess(const vector<string>& cmd, int stdin_fd, int stdout_fd,
   if (this->child_pid == -1) {
     throw runtime_error("fork failed: " + string_for_error(errno));
   }
-  if (!this->child_pid) {
+  if (this->child_pid == 0) {
+    // in child process
     replace_fd(stdin_fd, 0);
     replace_fd(stdout_fd, 1);
     replace_fd(stderr_fd, 2);
@@ -301,6 +302,8 @@ Subprocess::Subprocess(const vector<string>& cmd, int stdin_fd, int stdout_fd,
     } else {
       execvp(cmd[0].c_str(), (char* const *)argv.data());
     }
+    // if we get here, fork() worked, but execv_() failed: exit child process without even doing cleanup
+    _exit(errno);
   }
 
   for (int fd : parent_fds_to_close) {


### PR DESCRIPTION
Currently, when the constructor of `Subprocess` successfully forks the process, but fails to execute the new application (e.g. because it doesn't exist), it continues to execute the copy of the parent process, which will fail the moment the `Subprocess` object is destroyed: then, waiting on the child process (ourselves) will fail, leading to an exception being thrown. Starting with C++11, by default, destructors must not throw exceptions under penalty of`std::terminate` getting called. This leads to the child process crashing with, depending on the OS, a crashlog and an error dialog.

In `resource_dasm` this happens when `picttoppm` isn't installed, with the slightly confusing result that `resource_dasm` both crashes (the child process) and continues (the parent process).

To fix this, `SubProcess` exits as quickly and quietly as possible when it fails to execute the new application, without even doing any cleanup (by using `_exit` instead of `exit`).

Plus using `!` to check whether an integer is zero gives me a headache 😉.