### PR TITLE
BMP: Write full V5 header

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -66,16 +66,16 @@ struct WindowsBitmapInfoHeader {
   uint32_t  bitmask_g;
   uint32_t  bitmask_b;
   uint32_t  bitmask_a;
-  uint32_t  colorSpaceType;
-  uint32_t  chromacityEndpoints[9];
-  uint32_t  gammaRed;
-  uint32_t  gammaGreen;
-  uint32_t  gammaBlue;
+  uint32_t  color_space_type;
+  uint32_t  chromacity_endpoints[9];
+  uint32_t  gamma_r;
+  uint32_t  gamma_g;
+  uint32_t  gamma_b;
   
   // V5 header starts here
-  uint32_t  renderIntent;
-  uint32_t  colorProfileData;
-  uint32_t  colorProfileSize;
+  uint32_t  render_intent;
+  uint32_t  color_profile_data;
+  uint32_t  color_profile_size;
   uint32_t  reserved;
 
   // Size of basic BMP header (before V4)
@@ -118,8 +118,8 @@ static size_t init_bmp_header(WindowsBitmapHeader& header,
     header.info_header.bitmask_g = 0x0000FF00;
     header.info_header.bitmask_b = 0x00FF0000;
     header.info_header.bitmask_a = 0xFF000000;
-    header.info_header.colorSpaceType = 0x73524742; // LCS_sRGB / 'sRGB'
-    header.info_header.renderIntent = 8;            // LCS_GM_ABS_COLORIMETRIC
+    header.info_header.color_space_type = 0x73524742; // LCS_sRGB / 'sRGB'
+    header.info_header.render_intent = 8;             // LCS_GM_ABS_COLORIMETRIC
   }
   
   return header_size;


### PR DESCRIPTION
This:
1. more-or-less-correctly[*] sets the image's color space to sRGB
2. results in a correct header, which avoids errors when loading the BMP e.g. with ImageMagick ("invalid chromaticities")

Also fixed (but not tested, as BMP loading doesn't seem to be used): when loading a BMP file, use the file's header to determine how large it is instead of just assuming it's a V4 header.

[*] MacOS Classic doesn't use sRGB (which didn't exist until 1996), but a gamma value of 1.8 instead (sRGB is approximately 2.2). So saving image resources in sRGB color space changes the colors slightly. Technically correct would be to store the color space information in the BMP by writing a V5 header with:
- color space type 0 (LCS_CALIBRATED_RGB)
- chromacity endpoints
  - red: 0.638613861386139; 0.341584158415842; 0.0198019801980198
  - green: 0.298165137614679; 0.624770642201835; 0.0770642201834862
  - blue: 0.230558096980787, 0.102470265324794, 0.666971637694419 (these values were calculated by opening System 9.0.4's "Generic RGB Profile" in MacOS X's ColorSync assistant, and then using the tristimulus values XYZ shown there [to calculate xyz](https://en.wikipedia.org/wiki/CIE_1931_color_space#CIE_xy_chromaticity_diagram_and_the_CIE_xyY_color_space) and [sRGB's chromacity](https://en.wikipedia.org/wiki/SRGB#Gamut)). As you can see, they don't differ too much from sRGB's.
- red, green and blue gamma 1.8

(I hope I got the chromacities right...)
(I'm just noting these values down here so they don't get lost)