### PR TITLE
Fix for 32 bit builds on MacOS X

### DIFF
--- a/src/Strings.cc
+++ b/src/Strings.cc
@@ -1098,12 +1098,14 @@ size_t parse_size(const char* str) {
     unit_scale = MB_SIZE;
   } else if (*str == 'G' || *str == 'g') {
     unit_scale = GB_SIZE;
+#if SIZE_WIDTH > 32
   } else if (*str == 'T' || *str == 't') {
     unit_scale = TB_SIZE;
   } else if (*str == 'P' || *str == 'p') {
     unit_scale = PB_SIZE;
   } else if (*str == 'E' || *str == 'e') {
     unit_scale = EB_SIZE;
+#endif
   }
 
   return integer_part * unit_scale + static_cast<size_t>(fractional_part * unit_scale);


### PR DESCRIPTION
When `size_t` has only 32 bits, tera-, peta-, and exa-sizes aren't possible, and clang complains about assigning 64 bit integers to a 32 bit variable.

(related to issue fuzziqersoftware/resource_dasm#53)