### PR TITLE
Added PNG support to Image::save

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ link_directories("/usr/local/lib")
 # Library and executable definitions
 
 add_library(phosg src/Encoding.cc src/Filesystem.cc src/Hash.cc src/Image.cc src/JSON.cc src/Network.cc src/Process.cc src/Random.cc src/Strings.cc src/Time.cc src/Tools.cc src/UnitTest.cc)
-target_link_libraries(phosg pthread)
+target_link_libraries(phosg pthread z)
 
 # It seems that on some Linux variants (e.g. Raspbian) we also need -latomic,
 # but this library does not exist on others (e.g. Ubuntu) nor on macOS

--- a/src/Image.hh
+++ b/src/Image.hh
@@ -72,8 +72,9 @@ public:
 
   enum class Format {
     GRAYSCALE_PPM = 0,
-    COLOR_PPM = 1,
-    WINDOWS_BITMAP = 2,
+    COLOR_PPM,
+    WINDOWS_BITMAP,
+    PNG,
   };
 
   class unknown_format : virtual public std::runtime_error {


### PR DESCRIPTION
For the PR in resource_dasm. PNG is actually pretty simple when all you want is write a non-indexed image.