### PR TITLE
Make single-argument constructors explicit unless implicit conversion is intended

### DIFF
--- a/src/Image.hh
+++ b/src/Image.hh
@@ -25,9 +25,9 @@ public:
   Image(Image&&);
 
   // load a file (autodetect format)
-  Image(FILE* f);
-  Image(const char* filename);
-  Image(const std::string& filename);
+  explicit Image(FILE* f);
+  explicit Image(const char* filename);
+  explicit Image(const std::string& filename);
 
   // load from a file (raw data)
   Image(FILE* f, ssize_t width, ssize_t height, bool has_alpha = false,

--- a/src/JSON.hh
+++ b/src/JSON.hh
@@ -20,22 +20,22 @@ public:
   // thrown if the JSON contains an unterminated string, list, or dict)
   class parse_error : public std::runtime_error {
   public:
-    parse_error(const std::string& what);
+    explicit parse_error(const std::string& what);
   };
   // Thrown when a JSONObject is accessed as the wrong type
   class type_error : public std::runtime_error {
   public:
-    type_error(const std::string& what);
+    explicit type_error(const std::string& what);
   };
   // Thrown when a key doesn't exist in a dictionary
   class key_error : public std::runtime_error {
   public:
-    key_error(const std::string& what);
+    explicit key_error(const std::string& what);
   };
   // Thrown when an element doesn't exist in a list
   class index_error : public std::runtime_error {
   public:
-    index_error(const std::string& what);
+    explicit index_error(const std::string& what);
   };
 
   using list_type = std::vector<std::shared_ptr<JSONObject>>;
@@ -47,21 +47,21 @@ public:
 
   // Direct constructors. Use these when generating JSON to be sent/written/etc.
   JSONObject(); // null
-  JSONObject(bool x); // true/false
-  JSONObject(const char* x); // string
+  explicit JSONObject(bool x); // true/false
+  explicit JSONObject(const char* x); // string
   JSONObject(const char* x, size_t size); // string
-  JSONObject(const std::string& x); // string
-  JSONObject(std::string&& x); // string
-  JSONObject(int64_t x); // integer
-  JSONObject(double x); // float
-  JSONObject(const std::vector<JSONObject>& x); // list
-  JSONObject(std::vector<JSONObject>&& x); // list
-  JSONObject(const list_type& x); // list
-  JSONObject(list_type&& x); // list
-  JSONObject(const std::unordered_map<std::string, JSONObject>& x); // dict
-  JSONObject(std::unordered_map<std::string, JSONObject>&& x); // dict
-  JSONObject(const dict_type& x); // dict
-  JSONObject(dict_type&& x); // dict
+  explicit JSONObject(const std::string& x); // string
+  explicit JSONObject(std::string&& x); // string
+  explicit JSONObject(int64_t x); // integer
+  explicit JSONObject(double x); // float
+  explicit JSONObject(const std::vector<JSONObject>& x); // list
+  explicit JSONObject(std::vector<JSONObject>&& x); // list
+  explicit JSONObject(const list_type& x); // list
+  explicit JSONObject(list_type&& x); // list
+  explicit JSONObject(const std::unordered_map<std::string, JSONObject>& x); // dict
+  explicit JSONObject(std::unordered_map<std::string, JSONObject>&& x); // dict
+  explicit JSONObject(const dict_type& x); // dict
+  explicit JSONObject(dict_type&& x); // dict
 
   // Copy/move constructors
   JSONObject(const JSONObject& rhs) = default;

--- a/src/Process.hh
+++ b/src/Process.hh
@@ -39,7 +39,7 @@ pid_t getpid_cached();
 class Subprocess {
 public:
   Subprocess();
-  Subprocess(const std::vector<std::string>& cmd, int stdin_fd = -1,
+  explicit Subprocess(const std::vector<std::string>& cmd, int stdin_fd = -1,
       int stdout_fd = -1, int stderr_fd = -1, const std::string* cwd = nullptr,
       const std::unordered_map<std::string, std::string>* env = nullptr);
   Subprocess(const Subprocess&) = delete;


### PR DESCRIPTION
The `Image` one tripped me up when integrating PNG into resource_dasm, so I took the opportunity to go through phosg and check the single-argument constructors.