### PR TITLE
Fix compilation on Alpine Linux micro-distro

### DIFF
--- a/src/JSON.hh
+++ b/src/JSON.hh
@@ -23,7 +23,7 @@ private:
   template <typename T>
   inline static constexpr bool is_non_null_trivial_primitive_v = std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, bool>;
   template <typename T>
-  inline static constexpr bool is_primitive_v = std::is_same_v<T, nullptr_t> || std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, bool> || std::is_same_v<T, std::string>;
+  inline static constexpr bool is_primitive_v = std::is_same_v<T, std::nullptr_t> || std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, bool> || std::is_same_v<T, std::string>;
   template <typename T>
   inline static constexpr bool is_non_null_primitive_v = std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, bool> || std::is_same_v<T, std::string>;
 
@@ -83,7 +83,7 @@ public:
 
   // Primitive type constructors
   JSON(); // null
-  JSON(nullptr_t);
+  JSON(std::nullptr_t);
   JSON(bool x);
   JSON(const char* x);
   JSON(const char* x, size_t size);
@@ -159,7 +159,7 @@ public:
 
   // Comparison operators
   std::partial_ordering operator<=>(const JSON& other) const;
-  std::partial_ordering operator<=>(nullptr_t) const; // Same as is_null()
+  std::partial_ordering operator<=>(std::nullptr_t) const; // Same as is_null()
   std::partial_ordering operator<=>(bool v) const;
   std::partial_ordering operator<=>(const char* v) const;
   std::partial_ordering operator<=>(const std::string& v) const;
@@ -364,7 +364,7 @@ public:
 
   // Type inspectors
   inline bool is_null() const {
-    return holds_alternative<nullptr_t>(this->value);
+    return holds_alternative<std::nullptr_t>(this->value);
   }
   inline bool is_bool() const {
     return holds_alternative<bool>(this->value);
@@ -454,7 +454,7 @@ private:
   JSON(dict_type&& x);
 
   std::variant<
-      nullptr_t, // We use this type for JSON null
+      std::nullptr_t, // We use this type for JSON null
       bool,
       int64_t, // This is convertible to double implicitly in as_float()
       double, // This is convertible to int implicitly in as_int()


### PR DESCRIPTION
Alpine Linux is often used in Docker containers.

I'm using these dependencies :
`git cmake build-base gdb zlib-dev libevent-dev gnu-libiconv-dev ca-certificates linux-headers bash netcat-openbsd python3 procps`

With the fix I'm able to compile phosg in an Alpine Linux container and compilation on a "regular" Arch based system still works.
Without the fix there's and issue where compiler can't find definition of `nullptr_t`.
```
/newserv/phosg # make -j 8
[  2%] Building CXX object CMakeFiles/phosg.dir/src/JSON.cc.o
In file included from /newserv/phosg/src/JSON.cc:1:
/newserv/phosg/src/JSON.hh:27:67: error: 'nullptr_t' was not declared in this scope; did you mean 'std::nullptr_t'?
   27 |   inline static constexpr bool is_primitive_v = std::is_same_v<T, nullptr_t> || std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, bool> || std::is_same_v<T, std::string>;
      |                                                                   ^~~~~~~~~
      |                                                                   std::nullptr_t
In file included from /usr/include/c++/12.2.1/type_traits:38,
                 from /usr/include/c++/12.2.1/concepts:44,
                 from /usr/include/c++/12.2.1/compare:39,
                 from /newserv/phosg/src/JSON.hh:3:
/usr/include/c++/12.2.1/x86_64-alpine-linux-musl/bits/c++config.h:302:33: note: 'std::nullptr_t' declared here
  302 |   typedef decltype(nullptr)     nullptr_t;
      |                                 ^~~~~~~~~
/newserv/phosg/src/JSON.hh:87:7: error: unnecessary parentheses in declaration of 'nullptr_t' [-Werror=parentheses]
   87 |   JSON(nullptr_t);
      |       ^~~~~~~~~~~
/newserv/phosg/src/JSON.hh:87:7: note: remove parentheses
   87 |   JSON(nullptr_t);
      |       ^~~~~~~~~~~
      |       -         -
/newserv/phosg/src/JSON.hh:87:8: error: field 'nullptr_t' has incomplete type 'JSON'
   87 |   JSON(nullptr_t);
      |        ^~~~~~~~~
/newserv/phosg/src/JSON.hh:18:7: note: definition of 'class JSON' is not complete until the closing brace
   18 | class JSON {
      |       ^~~~
/newserv/phosg/src/JSON.hh:163:37: error: 'nullptr_t' is not a type
  163 |   std::partial_ordering operator<=>(nullptr_t) const; // Same as is_null()
      |                                     ^~~~~~~~~
/newserv/phosg/src/JSON.hh:458:7: error: invalid use of non-static data member 'JSON::nullptr_t'
  458 |       nullptr_t, // We use this type for JSON null
      |       ^~~~~~~~~
/newserv/phosg/src/JSON.hh:87:8: note: declared here
   87 |   JSON(nullptr_t);
      |        ^~~~~~~~~
/newserv/phosg/src/JSON.hh:464:16: error: template argument 1 is invalid
  464 |       dict_type>
      |                ^

```