### PR TITLE
Change phosg library link to PUBLIC visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ message(STATUS "Target architecture is ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 string(FIND ${CMAKE_HOST_SYSTEM_PROCESSOR} "armv" IS_LINUX_ARMV)
 if("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "aarch64" OR "${IS_LINUX_ARMV}" GREATER_EQUAL 0
   OR "${CMAKE_OSX_ARCHITECTURES}" STREQUAL "ppc")
-  target_link_libraries(phosg atomic)
+  target_link_libraries(phosg PUBLIC atomic)
 endif()
 
 add_executable(bindiff src/BinDiff.cc)


### PR DESCRIPTION
While building on a newer version of Rasbian, I got this error:

```
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Target architecture is aarch64
CMake Error at CMakeLists.txt:63 (target_link_libraries):
  The keyword signature for target_link_libraries has already been used with
  the target "phosg".  All uses of target_link_libraries with a target must
  be either all-keyword or all-plain.

  The uses of the keyword signature are here:

   * CMakeLists.txt:50 (target_link_libraries)



-- Configuring incomplete, errors occurred!
```

It appears that adding `PUBLIC` here should fix the error. Built locally without any issues.